### PR TITLE
Address issues in directory_files example

### DIFF
--- a/examples/directory_files.clj
+++ b/examples/directory_files.clj
@@ -6,15 +6,18 @@
 (defn -main
   [& [path & _]]
   (if path
-    (let [fw (-> (file-watcher :checksum :adler32)
-               (on-file-create #(println "  " (:path %3) "created." (str "(checksum: " (checksum %3) ")")))
-               (on-file-delete #(println "  " (:path %3) "deleted."))
-               (on-file-modify #(println "  " (:path %3) "modified." (str "(checksum: " (checksum %3) ")")))  
-               (unwatch-on-delete)
-               (run! :id :files :threads 4 :distribute :frequency :interval 200))
-          dw (-> (directory-watcher :recursive true :include-hidden false)
-               (on-file-create #(watch-entity! fw (:path %3) :created))
-               (run! :id :dirs :threads 2 :distribute :fair :interval 500))]
+    (let [fw  (-> (file-watcher :checksum :adler32)
+                  (on-file-create #(println "  " (:path %3) "created." (str "(checksum: " (checksum %3) ")")))
+                  (on-file-delete #(println "  " (:path %3) "deleted."))
+                  (on-file-modify #(println "  " (:path %3) "modified." (str "(checksum: " (checksum %3) ")")))
+                  (unwatch-on-delete)
+                  (run! :id :files :threads 4 :distribute :frequency :interval 200))
+          dw  (-> (directory-watcher :recursive true :include-hidden false)
+                  (on-directory-create (fn [_1 _2 dir]
+                    (doseq [child (:files (:panoptic.data.core/children dir))]
+                      (watch-entity! fw (str (:path dir) "/" child) :created))))
+                  (on-file-create #(watch-entity! fw (:path %3) :created))
+                  (run! :id :dirs :threads 2 :distribute :fair :interval 500))]
       (watch-entity! dw path :created)
      @dw)
     (println "Usage: lein run-example directory-files <Path>")))


### PR DESCRIPTION
I tried panoptic in order to watch all files in a directory (and subdirectories) for changes. While panoptic seems powerful, I wasn't able to do this. The directory_files example's intended behaviour seemed to offer a solution but it didn't really work right. I changed it so that it uses the directory watcher to add files into the file watcher (as was, I think, originally intended).
